### PR TITLE
Refresh git index in src/subtree.sh to avoid WSL stat-cache false positives

### DIFF
--- a/src/subtree.sh
+++ b/src/subtree.sh
@@ -22,6 +22,10 @@ case "$2" in
     *) usage ;;
 esac
 
+# Refresh the index to avoid spurious "working tree has modifications" from
+# stat-dirty files (common on WSL reading /mnt/c). Harmless when clean.
+git update-index --refresh >/dev/null || true
+
 case "$1" in
     pull) git subtree pull --prefix="$PREFIX" "$URL" main --squash ;;
     push) git subtree push --prefix="$PREFIX" "$URL" main ;;


### PR DESCRIPTION
## Summary
- On WSL reading `/mnt/c/...`, `./src/subtree.sh pull <name>` fails on the first invocation with `fatal: working tree has modifications. Cannot add.` even when `git status` reports a clean tree.
- Root cause: `git subtree` runs `git diff-index HEAD --exit-code`, which consults the index's cached stat info (mtime/ctime/inode/size). NTFS↔WSL stat drift makes files stat-dirty, so the check spuriously reports modifications. `git status` (or `git update-index --refresh`) rewrites the stat cache and the next run works.
- Fix: add `git update-index --refresh >/dev/null || true` before the pull/push dispatch. Cheap, safe, and does not mask real uncommitted changes — `git subtree` still refuses to run when content genuinely differs.

## Test plan
- [ ] In a fresh WSL shell (no `git status` run beforehand), `./src/subtree.sh pull corebackend` prints `Subtree is already at commit ...` without the `working tree has modifications` error.
- [ ] Same for `./src/subtree.sh pull coreweb`.
- [ ] `./src/subtree.sh push corebackend` / `push coreweb` → `Everything up-to-date`.
- [ ] With a real uncommitted change (`echo x >> README.md`), the script still refuses to pull (safety check preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)